### PR TITLE
Add optional param for logger

### DIFF
--- a/biloba/service.py
+++ b/biloba/service.py
@@ -297,7 +297,7 @@ class ConfigurableService(Service):
 
         self.config = biloba_config.Config(config)
 
-        super(ConfigurableService, self).__init__(logger)
+        super(ConfigurableService, self).__init__(logger=logger)
 
     def get_config_defaults(self):
         """


### PR DESCRIPTION
Allow ConfigurableService to pass an existing logger to its super constructor.
