### PR TITLE
Add autospawn decorator

### DIFF
--- a/biloba/__init__.py
+++ b/biloba/__init__.py
@@ -1,4 +1,5 @@
-from .service import Service, ConfigurableService
+from .service import *
+from .service import __all__ as service_all
 from .config import parse_address
 from .util import waitany
 
@@ -10,8 +11,10 @@ __version_info__ = _meta.version_info
 
 
 __all__ = [
-    'ConfigurableService',
-    'Service',
     'parse_address',
     'waitany',
 ]
+
+__all__.extend(service_all)
+
+del service_all

--- a/biloba/service.py
+++ b/biloba/service.py
@@ -5,6 +5,12 @@ import logbook
 
 from . import config as biloba_config, events
 
+__all__ = [
+    'Service',
+    'ConfigurableService',
+    'autospawn',
+]
+
 
 class Service(events.EventEmitter):
     """
@@ -291,6 +297,14 @@ class Service(events.EventEmitter):
         finally:
             self.stop()
 
+    def __enter__(self):
+        self.start()
+
+        return self
+
+    def __exit__(self, *exc_args):
+        self.stop()
+
 
 class ConfigurableService(Service):
     """
@@ -328,3 +342,14 @@ class ConfigurableService(Service):
             config.setdefault(key, value)
 
         return config
+
+
+def autospawn(func):
+    """
+    Decorator that will spawn the call in a service's greenlet pool
+    """
+    @functools.wraps(func)
+    def wrapped(self, *args, **kwargs):
+        return self.spawn(func, self, *args, **kwargs)
+
+    return wrapped

--- a/biloba/test/test_service.py
+++ b/biloba/test/test_service.py
@@ -462,3 +462,32 @@ class ConfigurableServiceTestCase(unittest.TestCase):
         svc = service.ConfigurableService(cfg)
 
         self.assertIs(svc.config, cfg)
+
+
+class AutospawnTestCase(unittest.TestCase):
+    """
+    Tests for `service.autospawn`.
+    """
+
+    def test_autospawn(self):
+        import gevent
+
+        class MyService(service.Service):
+            @service.autospawn
+            def my_func(self):
+                self.emit('autospawn')
+
+        my_service = MyService()
+        self.executed = False
+
+        @my_service.on('autospawn')
+        def on_autospawn():
+            self.executed = True
+
+        with my_service:
+            ret = my_service.my_func()
+
+            self.assertIsInstance(ret, gevent.Greenlet)
+            gevent.sleep(0.0)
+
+        self.assertTrue(self.executed)


### PR DESCRIPTION
Allow method calls on services to automatically be executed in the service's greenlet
pool.