### PR TITLE
Fix an issue services would immediately exit.

### DIFF
--- a/biloba/test/test_service.py
+++ b/biloba/test/test_service.py
@@ -465,9 +465,7 @@ class ServiceTestCase(unittest.TestCase):
 
         my_service = MyService()
 
-        my_service.start()
-
-        gevent.sleep(0)
+        my_service.join()
 
         self.assertTrue(self.started)
         self.assertTrue(self.stopped)

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,10 @@ setup_args = dict(
     name='biloba',
     version=get_version(),
     maintainer='Nick Joyce',
-    description=('Provides gevent primitives to orchestrate different' 
-                 'orthogonal servers and services together.'),
+    description=(
+        'Provides gevent primitives to orchestrate different'
+        'orthogonal servers and services together.'
+    ),
     url='https://github.com/njoyce/biloba',
     maintainer_email='nick@boxdesign.co.uk',
     packages=find_packages(),


### PR DESCRIPTION
The finish greenlet would be scheduled before the _run_thread, causing it all
to teardown the service prematurely.

Schedule the final cleanup only once the service has actually started.